### PR TITLE
Add GCB tester for upgrade.

### DIFF
--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -1,0 +1,111 @@
+---
+steps:
+    # We need to configure git since creating the merge commit is
+    # technically a commit.
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - config
+          - --global
+          - user.email
+          - magic-modules+differ@google.com
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - config
+          - --global
+          - user.name
+          - "Modular Magician Diff Process"
+
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - checkout
+          - origin/$_BASE_BRANCH
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - merge
+          - --no-ff
+          - origin/$_HEAD_BRANCH
+
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - clone
+          - https://github.com/GoogleCloudPlatform/magic-modules
+          - /workspace/mm-workdir
+
+      # none of the builtins are guaranteed to have gnu make.
+      # so we just reuse this container which we already have
+      # downloaded.  No big deal.
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      entrypoint: make
+      dir: /workspace/mm-workdir
+      args:
+        - upgrade-dcl
+        - FORCE_DCL=$COMMIT_SHA
+
+    - name: 'gcr.io/cloud-builders/git'
+      dir: /workspace/mm-workdir
+      args:
+          - diff
+
+    - name: 'gcr.io/cloud-builders/git'
+      dir: /workspace/mm-workdir
+      args:
+          - commit
+          - -a
+          - -m
+          - "upgrade DCL version"
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      id: tpgb-head
+      dir: /workspace/mm-workdir
+      args:
+          - 'head'
+          - 'terraform'
+          - 'beta'
+          - "dcl-$_PR_NUMBER"
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      id: tpgb-base
+      dir: /workspace/mm-workdir
+      args:
+          - 'base'
+          - 'terraform'
+          - 'beta'
+          - "dcl-$_PR_NUMBER"
+
+    - name: 'gcr.io/graphite-docker-images/terraform-tester'
+      id: tpgb-test
+      dir: /workspace/mm-workdir
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["tpgb-head", "tpgb-base"]
+      args:
+          - 'beta'
+          - "dcl-$_PR_NUMBER"
+          - $COMMIT_SHA
+          - $BUILD_ID
+          - $PROJECT_ID
+          - "9"  # Build step
+
+    - name: 'gcr.io/graphite-docker-images/terraform-vcr-tester'
+      id: tpg-vcr-test
+      dir: /workspace/mm-workdir
+      secretEnv: ["TEAMCITY_TOKEN", "GITHUB_TOKEN"]
+      waitFor: ["tpgb-test"]
+      timeout: 12000s
+      args:
+          - $_PR_NUMBER
+          - $COMMIT_SHA
+
+# Long timeout to enable waiting on VCR test
+timeout: 20000s
+options:
+    machineType: 'N1_HIGHCPU_32'
+
+secrets:
+    - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token
+      secretEnv:
+          GITHUB_TOKEN: CiQADkR4Nt6nHLI52Kc1W55OwpLdc4vjBfVR0SGQNzm6VSVj9lUSUQBfF82vVhn43A1jNYOv8ScoWgrZONwNrUabHfGjkvl+IZxcii0JlOVUawbscs4OJga0eitNNlagAOruLs6C926X20ZZPqWtH97ui6CKNvxgkQ==
+    - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/teamcity-token
+      secretEnv:
+          TEAMCITY_TOKEN: CiQAth83aSgKrb5ASI5XwE+yv62KbNtNG+O9gKXJzoflm65H7fESkwEASc1NF0oM3pHb5cUBAHcXZqFjEJrF4eGowPycUpKDmEncuQQSkm8v+dswSNXTXnX2C/reLpw9uGTw7G+K1kqA0sVrzYG3sTdDf/IcS//uloAerUff2wVIlV5rxV357PMkBl5dGyybnKMybgrXGl+CcW9PDLAwqfELWrr5zTSHy799dAhJZi1Wb5KbImmvvU5Z46g=


### PR DESCRIPTION
This creates a cloud build workflow which confirms that Terraform builds + the tests pass after a DCL upgrade.

This is part of go/dcl-downstream-testing - to turn that on, all I'll need to do is 

- add a push to the end where it pushes the relevant branch to main
- submit cl/398345422
- set up cloud build to trigger on this repo.