### PR TITLE
Add PSC Connection ID to Global Forwarding Rule Struct

### DIFF
--- a/services/google/compute/alpha/forwarding_rule.go
+++ b/services/google/compute/alpha/forwarding_rule.go
@@ -43,6 +43,7 @@ type ForwardingRule struct {
 	NetworkTier                   *ForwardingRuleNetworkTierEnum                `json:"networkTier"`
 	PortRange                     *string                                       `json:"portRange"`
 	Ports                         []string                                      `json:"ports"`
+	PscConnectionId               *string                                       `json:"pscConnectionId"`
 	Region                        *string                                       `json:"region"`
 	SelfLink                      *string                                       `json:"selfLink"`
 	ServiceLabel                  *string                                       `json:"serviceLabel"`
@@ -374,6 +375,7 @@ func (r *ForwardingRule) ID() (string, error) {
 		"networkTier":                   dcl.ValueOrEmptyString(nr.NetworkTier),
 		"portRange":                     dcl.ValueOrEmptyString(nr.PortRange),
 		"ports":                         dcl.ValueOrEmptyString(nr.Ports),
+		"pscConnectionId":               dcl.ValueOrEmptyString(nr.PscConnectionId),
 		"region":                        dcl.ValueOrEmptyString(nr.Region),
 		"selfLink":                      dcl.ValueOrEmptyString(nr.SelfLink),
 		"serviceLabel":                  dcl.ValueOrEmptyString(nr.ServiceLabel),

--- a/services/google/compute/alpha/forwarding_rule_internal.go
+++ b/services/google/compute/alpha/forwarding_rule_internal.go
@@ -705,6 +705,11 @@ func canonicalizeForwardingRuleDesiredState(rawDesired, rawInitial *ForwardingRu
 	} else {
 		canonicalDesired.Ports = rawDesired.Ports
 	}
+	if dcl.StringCanonicalize(rawDesired.PscConnectionId, rawInitial.PscConnectionId) {
+		canonicalDesired.PscConnectionId = rawInitial.PscConnectionId
+	} else {
+		canonicalDesired.PscConnectionId = rawDesired.PscConnectionId
+	}
 	if dcl.StringCanonicalize(rawDesired.Region, rawInitial.Region) {
 		canonicalDesired.Region = rawInitial.Region
 	} else {
@@ -867,6 +872,14 @@ func canonicalizeForwardingRuleNewState(c *Client, rawNew, rawDesired *Forwardin
 	} else {
 		if dcl.StringArrayCanonicalize(rawDesired.Ports, rawNew.Ports) {
 			rawNew.Ports = rawDesired.Ports
+		}
+	}
+
+	if dcl.IsNotReturnedByServer(rawNew.PscConnectionId) && dcl.IsNotReturnedByServer(rawDesired.PscConnectionId) {
+		rawNew.PscConnectionId = rawDesired.PscConnectionId
+	} else {
+		if dcl.StringCanonicalize(rawDesired.PscConnectionId, rawNew.PscConnectionId) {
+			rawNew.PscConnectionId = rawDesired.PscConnectionId
 		}
 	}
 
@@ -1439,6 +1452,13 @@ func diffForwardingRule(c *Client, desired, actual *ForwardingRule, opts ...dcl.
 		newDiffs = append(newDiffs, ds...)
 	}
 
+	if ds, err := dcl.Diff(desired.PscConnectionId, actual.PscConnectionId, dcl.Info{OutputOnly: true, OperationSelector: dcl.RequiresRecreate()}, fn.AddNest("PscConnectionId")); len(ds) != 0 || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		newDiffs = append(newDiffs, ds...)
+	}
+
 	if ds, err := dcl.Diff(desired.Region, actual.Region, dcl.Info{OperationSelector: dcl.RequiresRecreate()}, fn.AddNest("Region")); len(ds) != 0 || err != nil {
 		if err != nil {
 			return nil, err
@@ -1625,6 +1645,7 @@ func (r *ForwardingRule) urlNormalized() *ForwardingRule {
 	normalized.Name = dcl.SelfLinkToName(r.Name)
 	normalized.Network = dcl.SelfLinkToName(r.Network)
 	normalized.PortRange = dcl.SelfLinkToName(r.PortRange)
+	normalized.PscConnectionId = dcl.SelfLinkToName(r.PscConnectionId)
 	normalized.Region = dcl.SelfLinkToName(r.Region)
 	normalized.SelfLink = dcl.SelfLinkToName(r.SelfLink)
 	normalized.ServiceLabel = dcl.SelfLinkToName(r.ServiceLabel)
@@ -1835,6 +1856,7 @@ func flattenForwardingRule(c *Client, i interface{}, res *ForwardingRule) *Forwa
 	resultRes.NetworkTier = flattenForwardingRuleNetworkTierEnum(m["networkTier"])
 	resultRes.PortRange = dcl.FlattenString(m["portRange"])
 	resultRes.Ports = dcl.FlattenStringSlice(m["ports"])
+	resultRes.PscConnectionId = dcl.FlattenString(m["pscConnectionId"])
 	resultRes.Region = dcl.FlattenString(m["region"])
 	resultRes.SelfLink = dcl.FlattenString(m["selfLink"])
 	resultRes.ServiceLabel = dcl.FlattenString(m["serviceLabel"])

--- a/services/google/compute/beta/forwarding_rule.go
+++ b/services/google/compute/beta/forwarding_rule.go
@@ -43,6 +43,7 @@ type ForwardingRule struct {
 	NetworkTier                   *ForwardingRuleNetworkTierEnum                `json:"networkTier"`
 	PortRange                     *string                                       `json:"portRange"`
 	Ports                         []string                                      `json:"ports"`
+	PscConnectionId               *string                                       `json:"pscConnectionId"`
 	Region                        *string                                       `json:"region"`
 	SelfLink                      *string                                       `json:"selfLink"`
 	ServiceLabel                  *string                                       `json:"serviceLabel"`
@@ -374,6 +375,7 @@ func (r *ForwardingRule) ID() (string, error) {
 		"networkTier":                   dcl.ValueOrEmptyString(nr.NetworkTier),
 		"portRange":                     dcl.ValueOrEmptyString(nr.PortRange),
 		"ports":                         dcl.ValueOrEmptyString(nr.Ports),
+		"pscConnectionId":               dcl.ValueOrEmptyString(nr.PscConnectionId),
 		"region":                        dcl.ValueOrEmptyString(nr.Region),
 		"selfLink":                      dcl.ValueOrEmptyString(nr.SelfLink),
 		"serviceLabel":                  dcl.ValueOrEmptyString(nr.ServiceLabel),

--- a/services/google/compute/beta/forwarding_rule_internal.go
+++ b/services/google/compute/beta/forwarding_rule_internal.go
@@ -705,6 +705,11 @@ func canonicalizeForwardingRuleDesiredState(rawDesired, rawInitial *ForwardingRu
 	} else {
 		canonicalDesired.Ports = rawDesired.Ports
 	}
+	if dcl.StringCanonicalize(rawDesired.PscConnectionId, rawInitial.PscConnectionId) {
+		canonicalDesired.PscConnectionId = rawInitial.PscConnectionId
+	} else {
+		canonicalDesired.PscConnectionId = rawDesired.PscConnectionId
+	}
 	if dcl.StringCanonicalize(rawDesired.Region, rawInitial.Region) {
 		canonicalDesired.Region = rawInitial.Region
 	} else {
@@ -867,6 +872,14 @@ func canonicalizeForwardingRuleNewState(c *Client, rawNew, rawDesired *Forwardin
 	} else {
 		if dcl.StringArrayCanonicalize(rawDesired.Ports, rawNew.Ports) {
 			rawNew.Ports = rawDesired.Ports
+		}
+	}
+
+	if dcl.IsNotReturnedByServer(rawNew.PscConnectionId) && dcl.IsNotReturnedByServer(rawDesired.PscConnectionId) {
+		rawNew.PscConnectionId = rawDesired.PscConnectionId
+	} else {
+		if dcl.StringCanonicalize(rawDesired.PscConnectionId, rawNew.PscConnectionId) {
+			rawNew.PscConnectionId = rawDesired.PscConnectionId
 		}
 	}
 
@@ -1439,6 +1452,13 @@ func diffForwardingRule(c *Client, desired, actual *ForwardingRule, opts ...dcl.
 		newDiffs = append(newDiffs, ds...)
 	}
 
+	if ds, err := dcl.Diff(desired.PscConnectionId, actual.PscConnectionId, dcl.Info{OutputOnly: true, OperationSelector: dcl.RequiresRecreate()}, fn.AddNest("PscConnectionId")); len(ds) != 0 || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		newDiffs = append(newDiffs, ds...)
+	}
+
 	if ds, err := dcl.Diff(desired.Region, actual.Region, dcl.Info{OperationSelector: dcl.RequiresRecreate()}, fn.AddNest("Region")); len(ds) != 0 || err != nil {
 		if err != nil {
 			return nil, err
@@ -1625,6 +1645,7 @@ func (r *ForwardingRule) urlNormalized() *ForwardingRule {
 	normalized.Name = dcl.SelfLinkToName(r.Name)
 	normalized.Network = dcl.SelfLinkToName(r.Network)
 	normalized.PortRange = dcl.SelfLinkToName(r.PortRange)
+	normalized.PscConnectionId = dcl.SelfLinkToName(r.PscConnectionId)
 	normalized.Region = dcl.SelfLinkToName(r.Region)
 	normalized.SelfLink = dcl.SelfLinkToName(r.SelfLink)
 	normalized.ServiceLabel = dcl.SelfLinkToName(r.ServiceLabel)
@@ -1835,6 +1856,7 @@ func flattenForwardingRule(c *Client, i interface{}, res *ForwardingRule) *Forwa
 	resultRes.NetworkTier = flattenForwardingRuleNetworkTierEnum(m["networkTier"])
 	resultRes.PortRange = dcl.FlattenString(m["portRange"])
 	resultRes.Ports = dcl.FlattenStringSlice(m["ports"])
+	resultRes.PscConnectionId = dcl.FlattenString(m["pscConnectionId"])
 	resultRes.Region = dcl.FlattenString(m["region"])
 	resultRes.SelfLink = dcl.FlattenString(m["selfLink"])
 	resultRes.ServiceLabel = dcl.FlattenString(m["serviceLabel"])

--- a/services/google/compute/forwarding_rule.go
+++ b/services/google/compute/forwarding_rule.go
@@ -43,6 +43,7 @@ type ForwardingRule struct {
 	NetworkTier                   *ForwardingRuleNetworkTierEnum                `json:"networkTier"`
 	PortRange                     *string                                       `json:"portRange"`
 	Ports                         []string                                      `json:"ports"`
+	PscConnectionId               *string                                       `json:"pscConnectionId"`
 	Region                        *string                                       `json:"region"`
 	SelfLink                      *string                                       `json:"selfLink"`
 	ServiceLabel                  *string                                       `json:"serviceLabel"`
@@ -374,6 +375,7 @@ func (r *ForwardingRule) ID() (string, error) {
 		"networkTier":                   dcl.ValueOrEmptyString(nr.NetworkTier),
 		"portRange":                     dcl.ValueOrEmptyString(nr.PortRange),
 		"ports":                         dcl.ValueOrEmptyString(nr.Ports),
+		"pscConnectionId":               dcl.ValueOrEmptyString(nr.PscConnectionId),
 		"region":                        dcl.ValueOrEmptyString(nr.Region),
 		"selfLink":                      dcl.ValueOrEmptyString(nr.SelfLink),
 		"serviceLabel":                  dcl.ValueOrEmptyString(nr.ServiceLabel),

--- a/services/google/compute/forwarding_rule_internal.go
+++ b/services/google/compute/forwarding_rule_internal.go
@@ -705,6 +705,11 @@ func canonicalizeForwardingRuleDesiredState(rawDesired, rawInitial *ForwardingRu
 	} else {
 		canonicalDesired.Ports = rawDesired.Ports
 	}
+	if dcl.StringCanonicalize(rawDesired.PscConnectionId, rawInitial.PscConnectionId) {
+		canonicalDesired.PscConnectionId = rawInitial.PscConnectionId
+	} else {
+		canonicalDesired.PscConnectionId = rawDesired.PscConnectionId
+	}
 	if dcl.StringCanonicalize(rawDesired.Region, rawInitial.Region) {
 		canonicalDesired.Region = rawInitial.Region
 	} else {
@@ -867,6 +872,14 @@ func canonicalizeForwardingRuleNewState(c *Client, rawNew, rawDesired *Forwardin
 	} else {
 		if dcl.StringArrayCanonicalize(rawDesired.Ports, rawNew.Ports) {
 			rawNew.Ports = rawDesired.Ports
+		}
+	}
+
+	if dcl.IsNotReturnedByServer(rawNew.PscConnectionId) && dcl.IsNotReturnedByServer(rawDesired.PscConnectionId) {
+		rawNew.PscConnectionId = rawDesired.PscConnectionId
+	} else {
+		if dcl.StringCanonicalize(rawDesired.PscConnectionId, rawNew.PscConnectionId) {
+			rawNew.PscConnectionId = rawDesired.PscConnectionId
 		}
 	}
 
@@ -1439,6 +1452,13 @@ func diffForwardingRule(c *Client, desired, actual *ForwardingRule, opts ...dcl.
 		newDiffs = append(newDiffs, ds...)
 	}
 
+	if ds, err := dcl.Diff(desired.PscConnectionId, actual.PscConnectionId, dcl.Info{OutputOnly: true, OperationSelector: dcl.RequiresRecreate()}, fn.AddNest("PscConnectionId")); len(ds) != 0 || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		newDiffs = append(newDiffs, ds...)
+	}
+
 	if ds, err := dcl.Diff(desired.Region, actual.Region, dcl.Info{OperationSelector: dcl.RequiresRecreate()}, fn.AddNest("Region")); len(ds) != 0 || err != nil {
 		if err != nil {
 			return nil, err
@@ -1625,6 +1645,7 @@ func (r *ForwardingRule) urlNormalized() *ForwardingRule {
 	normalized.Name = dcl.SelfLinkToName(r.Name)
 	normalized.Network = dcl.SelfLinkToName(r.Network)
 	normalized.PortRange = dcl.SelfLinkToName(r.PortRange)
+	normalized.PscConnectionId = dcl.SelfLinkToName(r.PscConnectionId)
 	normalized.Region = dcl.SelfLinkToName(r.Region)
 	normalized.SelfLink = dcl.SelfLinkToName(r.SelfLink)
 	normalized.ServiceLabel = dcl.SelfLinkToName(r.ServiceLabel)
@@ -1835,6 +1856,7 @@ func flattenForwardingRule(c *Client, i interface{}, res *ForwardingRule) *Forwa
 	resultRes.NetworkTier = flattenForwardingRuleNetworkTierEnum(m["networkTier"])
 	resultRes.PortRange = dcl.FlattenString(m["portRange"])
 	resultRes.Ports = dcl.FlattenStringSlice(m["ports"])
+	resultRes.PscConnectionId = dcl.FlattenString(m["pscConnectionId"])
 	resultRes.Region = dcl.FlattenString(m["region"])
 	resultRes.SelfLink = dcl.FlattenString(m["selfLink"])
 	resultRes.ServiceLabel = dcl.FlattenString(m["serviceLabel"])


### PR DESCRIPTION
Add `pscConnectionId` to the struct as is referenced in the docs. This allows the Google Terraform Provider to output the PSC Connection ID for further processing or traffic filtering using the ID. For example, Elastic Cloud PSC Traffic Filtering. https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules#:~:text=to%20INTERNAL.-,pscConnectionId,string%20(uint64%20format),-%5BOutput%20Only%5D%20The

Please see this pullrequest that directly needs this change.
https://github.com/hashicorp/terraform-provider-google/pull/11767
