### PR TITLE
services/google/pubsub: fix dropped errors

### DIFF
--- a/services/google/pubsub/alpha/topic_internal.go
+++ b/services/google/pubsub/alpha/topic_internal.go
@@ -1,11 +1,11 @@
 // Copyright 2023 Google LLC. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -341,6 +341,9 @@ func (op *createTopicOperation) do(ctx context.Context, r *Topic, c *Client) err
 		}
 		return getResp, nil
 	}, c.Config.RetryProvider)
+	if err != nil {
+		return err
+	}
 
 	if _, err := c.GetTopic(ctx, r); err != nil {
 		c.Config.Logger.WarningWithContextf(ctx, "get returned error: %v", err)

--- a/services/google/pubsub/beta/topic_internal.go
+++ b/services/google/pubsub/beta/topic_internal.go
@@ -1,11 +1,11 @@
 // Copyright 2023 Google LLC. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -341,6 +341,9 @@ func (op *createTopicOperation) do(ctx context.Context, r *Topic, c *Client) err
 		}
 		return getResp, nil
 	}, c.Config.RetryProvider)
+	if err != nil {
+		return err
+	}
 
 	if _, err := c.GetTopic(ctx, r); err != nil {
 		c.Config.Logger.WarningWithContextf(ctx, "get returned error: %v", err)

--- a/services/google/pubsub/topic_internal.go
+++ b/services/google/pubsub/topic_internal.go
@@ -1,11 +1,11 @@
 // Copyright 2023 Google LLC. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -341,6 +341,9 @@ func (op *createTopicOperation) do(ctx context.Context, r *Topic, c *Client) err
 		}
 		return getResp, nil
 	}, c.Config.RetryProvider)
+	if err != nil {
+		return err
+	}
 
 	if _, err := c.GetTopic(ctx, r); err != nil {
 		c.Config.Logger.WarningWithContextf(ctx, "get returned error: %v", err)


### PR DESCRIPTION
This fixes a dropped `err` variable across its three implementations in `services/google/pubsub`.

My editor automatically picked up some `gofmt` changes in the license headers, as well.